### PR TITLE
Fixing a NullPointerException

### DIFF
--- a/src/org/omnirom/omniswitch/RecentTasksLoader.java
+++ b/src/org/omnirom/omniswitch/RecentTasksLoader.java
@@ -396,7 +396,9 @@ public class RecentTasksLoader {
                         item.setLabel(label);
                         preloadTaskNum++;
                     } else {
+                        if (item !=null) {
                         item.setDefaultIcon(mDefaultAppIcon);
+                        }
                     }
                     if (withThumbs && mHasThumbPermissions && preloadedThumbNum < THUMB_INIT_LOAD) {
                         Bitmap b = getThumbnail(item.persistentTaskId);


### PR DESCRIPTION
This fixes

07-19 10:38:36.450 E/AndroidRuntime(3244): Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'void org.omnirom.omniswitch.TaskDescription.setDefaultIcon(android.graphics.drawable.Drawable)' on a null object reference